### PR TITLE
Add WDP210601-18

### DIFF
--- a/src/components/layout/Footer/Footer.js
+++ b/src/components/layout/Footer/Footer.js
@@ -17,7 +17,7 @@ const Footer = ({ children }) => (
     <div className={styles.footerMenu}>
       <div className='container'>
         <div className='row'>
-          <div className='col'>
+          <div className='col-xs-12 col-sm-6 col-md-3'>
             <div className={styles.menuWrapper}>
               <h6>Information</h6>
               <ul>
@@ -36,7 +36,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-xs-12 col-sm-6 col-md-3'>
             <div className={styles.menuWrapper}>
               <h6>My account</h6>
               <ul>
@@ -55,7 +55,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-xs-12 col-sm-6 col-md-3'>
             <div className={styles.menuWrapper}>
               <h6>Information</h6>
               <ul>
@@ -74,7 +74,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-xs-12 col-sm-6 col-md-3'>
             <div className={styles.menuWrapper}>
               <h6>Orders</h6>
               <ul>
@@ -100,11 +100,11 @@ const Footer = ({ children }) => (
     <div className={styles.bottomBar}>
       <div className='container'>
         <div className='row align-items-center'>
-          <div className='col'></div>
-          <div className={'col text-center ' + styles.copyright}>
+          <div className='col-sm-12 col-lg-4 text-center'></div>
+          <div className={'col-sm-6 col-lg-4 text-center ' + styles.copyright}>
             <p>©Copyright 2016 Bazar | All Rights Reserved</p>
           </div>
-          <div className={'col text-right ' + styles.socialMedia}>
+          <div className={'col-sm-6 col-lg-4 text-right ' + styles.socialMedia}>
             <ul>
               <li>
                 <a href='#'>

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -1,4 +1,5 @@
 @import "../../../styles/settings.scss";
+@import "../../../styles/global.scss";
 
 .root {
   .footerMenu {
@@ -44,6 +45,12 @@
     }
   }
 
+  @include tablet {
+    img {
+      width: 160px;
+    }
+  }
+
   .bottomBar {
     background-color: $footer-claim-bg;
 
@@ -83,3 +90,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Górna partia stopki (szare tło, linki ikony metod płatności) na tabletach się mieści, ale na mniejszych ekranach chce żeby były po dwie sekcje na szerokość, a jak w najmniejszych rozdzielczościach nie będą się mieścić, to nawet 1 na szerokość (tylko w tych najmniejszych). 

W tym dolnym pasku Klient chce żeby na tablecie copyright był do lewej, a socjalki do prawej. Tam jest obecnie specjalnie zostawione miejsce po lewej, w którym na razie niczego nie ma, ale Klient prosił o uwzględnienie że może być coś dodane i wtedy na tabletach to coś ma być wyśrodkowane i na całą szerokość (nad copyright i socjalkami). 